### PR TITLE
Fixed 8bitworkshop URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ A minimalist sound engine in C for NROM homebrew games.
 
 Not meant as a Pently replacement, only as a simple sound engine for SMB1-ish games.
 
-[Open this project in 8bitworkshop](http://8bitworkshop.com/redir.html?platform=nes&importURL=https%3A%2F%2Fgithub.com%2Fadrian09011%2FNESSoundEngineC&file=music.c).
+[Open this project in 8bitworkshop](http://8bitworkshop.com/redir.html?platform=nes&githubURL=https%3A%2F%2Fgithub.com%2Fadrian09011%2FNESSoundEngineC&file=music.c).


### PR DESCRIPTION
There was a bug in the IDE when it created the URL in the README -- sorry about that! It should work now.